### PR TITLE
Analytics.js bridge updates

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -55,7 +55,7 @@ trait Service {
     doNotTrack: Boolean,
     contentType: Option[ContentType] = None,
     spAnonymous: Option[String] = None,
-    analyticsJsEvent: Option[AnalyticsJsBridge.EventType] = None
+    analyticsJsEvent: Option[AnalyticsJsBridge.Event] = None
   ): HttpResponse
   def cookieName: Option[String]
   def doNotTrackCookie: Option[DntCookieMatcher]
@@ -113,7 +113,7 @@ class CollectorService(
     doNotTrack: Boolean,
     contentType: Option[ContentType] = None,
     spAnonymous: Option[String],
-    analyticsJsEvent: Option[AnalyticsJsBridge.EventType] = None
+    analyticsJsEvent: Option[AnalyticsJsBridge.Event] = None
   ): HttpResponse = {
     val (ipAddress, partitionKey) = ipAndPartitionKey(ip, config.streams.useIpAddressAsPartitionKey)
 
@@ -249,7 +249,7 @@ class CollectorService(
     networkUserId: String,
     contentType: Option[String],
     spAnonymous: Option[String],
-    analyticsJsEvent: Option[AnalyticsJsBridge.EventType] = None
+    analyticsJsEvent: Option[AnalyticsJsBridge.Event] = None
   ): CollectorPayload = {
     val customBody = analyticsJsEvent match {
       case Some(eventType) =>
@@ -258,7 +258,7 @@ class CollectorService(
           .parser
           .parse(body.getOrElse("{}"))
           .getOrElse(throw new RuntimeException("The request body must be a JSON-encoded Analytic.js payload"))
-        val payload = AnalyticsJsBridge.createSnowplowPayload(jsonBody, eventType)
+        val payload = AnalyticsJsBridge.createSnowplowPayload(jsonBody, eventType, networkUserId)
         Some(payload.noSpaces)
 
       case None => body
@@ -310,7 +310,7 @@ class CollectorService(
     pixelExpected: Boolean,
     bounce: Boolean,
     redirectMacroConfig: RedirectMacroConfig,
-    analyticsJsEvent: Option[AnalyticsJsBridge.EventType] = None
+    analyticsJsEvent: Option[AnalyticsJsBridge.Event] = None
   ): HttpResponse =
     if (redirect) {
       val r = buildRedirectHttpResponse(event, queryParams, redirectMacroConfig)
@@ -324,7 +324,7 @@ class CollectorService(
   def buildUsualHttpResponse(
     pixelExpected: Boolean,
     bounce: Boolean,
-    analyticsJsEvent: Option[AnalyticsJsBridge.EventType] = None
+    analyticsJsEvent: Option[AnalyticsJsBridge.Event] = None
   ): HttpResponse =
     (pixelExpected, bounce, analyticsJsEvent) match {
       case (true, true, _) => HttpResponse(StatusCodes.Found)

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorRouteSpec.scala
@@ -48,7 +48,7 @@ class CollectorRouteSpec extends Specification with Specs2RouteTest {
           doNotTrack: Boolean,
           contentType: Option[ContentType] = None,
           spAnonymous: Option[String] = spAnonymous,
-          analyticsJsEvent: Option[AnalyticsJsBridge.EventType] = None
+          analyticsJsEvent: Option[AnalyticsJsBridge.Event] = None
         ): HttpResponse =
           if (analyticsJsEvent.isDefined) {
             HttpResponse(200, entity = AnalyticsJsBridge.jsonResponse.noSpaces)

--- a/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -535,7 +535,11 @@ class CollectorServiceSpec extends Specification {
         service.buildUsualHttpResponse(false, true) shouldEqual HttpResponse(200, entity = "ok")
       }
       "send back the analytics.js supported response" in {
-        service.buildUsualHttpResponse(false, true, Some(AnalyticsJsBridge.EventType.Page)) shouldEqual HttpResponse(
+        service.buildUsualHttpResponse(
+          false,
+          true,
+          Some(AnalyticsJsBridge.Event(AnalyticsJsBridge.EventType.Page, None, None))
+        ) shouldEqual HttpResponse(
           200,
           entity = """{"success":true}"""
         )
@@ -970,7 +974,7 @@ class CollectorServiceSpec extends Specification {
         request = HttpRequest(),
         pixelExpected = false,
         doNotTrack = false,
-        analyticsJsEvent = Some(eventType)
+        analyticsJsEvent = Some(AnalyticsJsBridge.Event(eventType, None, None))
       )
 
       good.storedRawEvents must have size 1


### PR DESCRIPTION
- Set network_userid to the same value set by the normal collector routes.
- Set user_id to the value from the ajs_user_id cookie, fallback to the Segment payload -> userId value when the cookie is missing.
- Set domain_userid to the value from the ajs_anonymous_id cookie.