### PR TITLE
Upgrade netty to 4.1.132.Final in order to patch CVE-2026-33870 and C…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ lazy val kinesisSettings =
       Dependencies.Libraries.kinesis,
       Dependencies.Libraries.sts,
       Dependencies.Libraries.sqs,
+      Dependencies.Libraries.nettyAll,
       // integration tests dependencies
       Dependencies.Libraries.specs2It,
       Dependencies.Libraries.specs2CEIt
@@ -157,7 +158,8 @@ lazy val sqsSettings =
     Docker / packageName := "scala-stream-collector-sqs",
     libraryDependencies ++= Seq(
       Dependencies.Libraries.sqs,
-      Dependencies.Libraries.sts
+      Dependencies.Libraries.sts,
+      Dependencies.Libraries.nettyAll
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,9 +40,9 @@ object Dependencies {
     val jnrUnixsock = "0.38.22"
     val protobuf    = "3.25.5"
     val guava       = "32.1.3-jre"
-    val nettyAll    = "4.1.130.Final"
+    val nettyAll    = "4.1.132.Final"
     val commonsLang = "3.18.0"
-    val grpcNettyShaded = "1.76.3"
+    val grpcNettyShaded = "1.80.0"
 
     // Scala
     val collectorPayload = "0.0.0"


### PR DESCRIPTION
…VE-2026-33874. Override transitive netty dependencies versions for sqs and kinesis modules