### PR TITLE
Upgrade Apache Thrift to 0.23.0 in order to patch CVE. …

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
+++ b/core/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorService.scala
@@ -18,7 +18,6 @@ import java.net.{MalformedURLException, URL}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Instant
 import java.util.UUID
-import org.apache.commons.codec.binary.Base64
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -69,7 +68,7 @@ trait Service {
 
 object CollectorService {
   // Contains an invisible pixel to return for `/i` requests.
-  val pixel = Base64.decodeBase64("R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
+  val pixel = java.util.Base64.getDecoder.decode("R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
 }
 
 class CollectorService(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     val config      = "1.4.3"
     val rabbitMQ    = "5.21.0"
     val jackson     = "2.21.1"
-    val thrift      = "0.16.0"
+    val thrift      = "0.23.0"
     val jnrUnixsock = "0.38.22"
     val protobuf    = "3.25.5"
     val guava       = "32.1.3-jre"

--- a/stdout/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/StdoutSink.scala
+++ b/stdout/src/main/scala/com.snowplowanalytics.snowplow.collectors.scalastream/sinks/StdoutSink.scala
@@ -19,8 +19,6 @@
 package com.snowplowanalytics.snowplow.collectors.scalastream
 package sinks
 
-import org.apache.commons.codec.binary.Base64
-
 class StdoutSink(val maxBytes: Int, streamName: String) extends Sink {
 
   // Print a Base64-encoded event.
@@ -28,11 +26,11 @@ class StdoutSink(val maxBytes: Int, streamName: String) extends Sink {
     streamName match {
       case "out" =>
         events.foreach { e =>
-          println(Base64.encodeBase64String(e))
+          println(java.util.Base64.getEncoder.encodeToString(e))
         }
       case "err" =>
         events.foreach { e =>
-          Console.err.println(Base64.encodeBase64String(e))
+          Console.err.println(java.util.Base64.getEncoder.encodeToString(e))
         }
     }
 


### PR DESCRIPTION
Use native JDK methods for Base64 instead of dropped transitive commons-codec dependency.