### PR TITLE
Fixes/pubsub sink test

### DIFF
--- a/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
+++ b/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
@@ -162,15 +162,17 @@ class GooglePubSubCollectorSpec extends Specification with CatsIO with BeforeAft
               Containers.emulatorHostPort,
               List(topicGood, topicBad)
             )
-            _                 <- IO.sleep(10.second)
             _                 <- log(testName, "Checking /sink-health after creating the topics")
             statusAfterCreate <- Http.status(request)
-            collectorOutput <- PubSub.consume(
+            collectorOutput <- PubSub.consumeWithRetry(
               Containers.projectId,
               Containers.emulatorHost,
               Containers.emulatorHostPort,
               topicGood,
-              topicBad
+              topicBad,
+              nbGood,
+              nbBad,
+              30.seconds
             )
             _ <- printBadRows(testName, collectorOutput.bad)
           } yield {

--- a/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
+++ b/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
@@ -52,17 +52,14 @@ class GooglePubSubCollectorSpec extends Specification with CatsIO with BeforeAft
       RetryPolicies.constantDelay[IO](1.second)
     )
 
-    Http.status(request).flatMap { status =>
-      if (status == Status.Ok) {
-        IO.pure(status)
-      } else {
-        IO.raiseError(new RuntimeException(s"Health endpoint not ready yet: $status"))
-      }
-    }.retryingOnFailures(
-      _ => true,
-      retryPolicy,
-      (_, _) => IO.unit
-    )
+    Http.status(request)
+      .attempt
+      .map(_.getOrElse(Status.ServiceUnavailable))
+      .retryingOnFailures(
+        _ != Status.Ok,
+        retryPolicy,
+        (_, _) => IO.unit
+      )
   }
 
   "collector-pubsub" should {

--- a/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
+++ b/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/GooglePubSubCollectorSpec.scala
@@ -27,6 +27,9 @@ import org.specs2.specification.BeforeAfterAll
 
 import org.testcontainers.containers.GenericContainer
 
+import retry.syntax.all._
+import retry.RetryPolicies
+
 import com.snowplowanalytics.snowplow.collectors.scalastream.it.utils._
 import com.snowplowanalytics.snowplow.collectors.scalastream.it.{EventGenerator, Http}
 
@@ -41,6 +44,26 @@ class GooglePubSubCollectorSpec extends Specification with CatsIO with BeforeAft
   val stopTimeout = 20.second
 
   val maxBytes = 10000
+
+  /** Poll the health endpoint until it returns 200 OK or timeout */
+  def waitForHealthy(request: Request[IO], maxWait: FiniteDuration): IO[Status] = {
+    val retryPolicy = RetryPolicies.limitRetriesByCumulativeDelay[IO](
+      maxWait,
+      RetryPolicies.constantDelay[IO](1.second)
+    )
+
+    Http.status(request).flatMap { status =>
+      if (status == Status.Ok) {
+        IO.pure(status)
+      } else {
+        IO.raiseError(new RuntimeException(s"Health endpoint not ready yet: $status"))
+      }
+    }.retryingOnFailures(
+      _ => true,
+      retryPolicy,
+      (_, _) => IO.unit
+    )
+  }
 
   "collector-pubsub" should {
     "be able to parse the minimal config" in {
@@ -162,8 +185,9 @@ class GooglePubSubCollectorSpec extends Specification with CatsIO with BeforeAft
               Containers.emulatorHostPort,
               List(topicGood, topicBad)
             )
+            _                 <- IO.sleep(12.seconds)
             _                 <- log(testName, "Checking /sink-health after creating the topics")
-            statusAfterCreate <- Http.status(request)
+            statusAfterCreate <- waitForHealthy(request, 30.seconds)
             collectorOutput <- PubSub.consumeWithRetry(
               Containers.projectId,
               Containers.emulatorHost,

--- a/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/PubSub.scala
+++ b/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/PubSub.scala
@@ -32,6 +32,9 @@ import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 import cats.implicits._
 
 import cats.effect.{IO, Resource}
+import scala.concurrent.duration._
+import retry.syntax.all._
+import retry.RetryPolicies
 
 import com.snowplowanalytics.snowplow.collectors.scalastream.it.utils._
 import com.snowplowanalytics.snowplow.collectors.scalastream.it.CollectorOutput
@@ -69,6 +72,40 @@ object PubSub {
         bad     <- IO(badRaw.map(parseBadRow))
       } yield CollectorOutput(good, bad)
     }
+  }
+
+  /** Consume messages with retry logic, polling until expected count is reached or timeout.
+    * This is useful for tests where messages may not be immediately available.
+    */
+  def consumeWithRetry(
+    projectId: String,
+    emulatorHost: String,
+    emulatorPort: Int,
+    subscriptionGood: String,
+    subscriptionBad: String,
+    expectedGood: Int,
+    expectedBad: Int,
+    maxWait: FiniteDuration
+  ): IO[CollectorOutput] = {
+    val retryPolicy = RetryPolicies.limitRetriesByCumulativeDelay[IO](
+      maxWait,
+      RetryPolicies.constantDelay[IO](2.seconds)
+    )
+
+    def checkMessages: IO[CollectorOutput] =
+      consume(projectId, emulatorHost, emulatorPort, subscriptionGood, subscriptionBad).flatMap { output =>
+        if (output.good.size >= expectedGood && output.bad.size >= expectedBad) {
+          IO.pure(output)
+        } else {
+          IO.raiseError(new RuntimeException(s"Not enough messages yet: good=${output.good.size}/$expectedGood, bad=${output.bad.size}/$expectedBad"))
+        }
+      }
+
+    checkMessages.retryingOnFailures(
+      _ => true,  // Retry on all errors
+      retryPolicy,
+      (_, _) => IO.unit
+    )
   }
 
   private def resourceProviders(


### PR DESCRIPTION
Fix race condition in pubsub sink-health integration test

The sink-health test was intermittently failing with "0 != 10" because it used a fixed 10-second delay that coincided with the collector's retry interval. This created a race condition where the test sometimes checked for messages at the exact moment retry fired, before PubSub delivery completed.

Changes:
- Add 12-second sleep to guarantee at least one retry cycle completes
- Implement waitForHealthy() to poll health endpoint with retry logic
- Implement consumeWithRetry() to poll for messages with configurable timeout
- Use 30-second polling timeout as buffer for slow CI environments
